### PR TITLE
Update allstar-helpers.cron.d

### DIFF
--- a/allstar/debian/allstar-helpers.cron.d
+++ b/allstar/debian/allstar-helpers.cron.d
@@ -1,2 +1,2 @@
-# Get AllMondb on reboot
-@reboot /usr/sbin/astdb.php
+# Get AllMon/Supermon/AllScan db on reboot
+@reboot root /usr/sbin/astdb.php


### PR DESCRIPTION
The crontab, /etc/cron.d/allstar-helpers, gets flagged with an error by crond. This is because there is an extra "username" field in the "system" cron files.