### PR TITLE
auto[re]conf creates/leaves `pwd` directory

### DIFF
--- a/asterisk/configure.ac
+++ b/asterisk/configure.ac
@@ -11,8 +11,6 @@ AC_CANONICAL_HOST
 # check existence of the package
 AC_CONFIG_SRCDIR([main/asterisk.c])
 
-AC_CONFIG_AUX_DIR(`pwd`)
-
 # specify output header file
 AC_CONFIG_HEADER(include/asterisk/autoconfig.h)
 


### PR DESCRIPTION
The AC_CONFIG_AUX_DIR directive in the ./asterisk/configure.ac file results in the creation of a `pwd` directory.  It is unclear what the directive is supposed to accomplish but removing it (a) doesn't appear to result in any build issues and (b) does not create the errant directory.